### PR TITLE
API endpoints documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,22 @@
 React app that talks to a RESTful-ish API written in Python/Flask.
 
 API endpoints:
-```
-  /user/<user>/image         Image for user, redirects to S3. POST/DELETE is supported if the user is logged in.
-  /user/<user>/image/<size>  Resized image for user
-```
+
+| Path | Method | Requires Log-in | Result |
+| ----- | ----- | ----- | ----- |
+| `/` | `GET` | Yes | Displays index/searchbar |
+| `/me` | `GET` | Yes | Displays an object with kth `uid` and wheter the user has uploaded an image to `s3`(`personal`) |
+| `/user/<user>/image` | `GET` | No | Image for user, redirects to `s3` |
+| `/user/<user>/image` | `POST` | Yes | Uploads image for user to `s3` |
+| `/user/<user>/image` | `DELETE` | Yes | Deletes image for user from `s3` |
+| `/user/<user>/image/<size>` | `GET` | No | Resized image for user |
+| `/users/<query>` | `GET`| No | Redirects to `hodis`, quering all information, displaying all matching as objects in an array |
+| `/ugkthid/<ugid>` | `GET` | No | Redirects to `hodis`, displaying information of `ugKthid` as an object |
+| `/user/<user>` | `GET`,`POST` | No | Redirects to `hodis`, displaying information of `uid` as an object |
+
+If log-in is required, user will be redirected to `login.kth.se` if not already.
+
+Information displayed in `hodis` is `ugKthid`,`uid`,`on`,`mail`,`givenName`,`displayName`,`year` and`tag`.
 
 Required environment variables:
 ```


### PR DESCRIPTION
Remakes the endpoints section of `README.md` to include all endpoints and presents them as a table.

Part of #11.