### PR TITLE
Set Cache-Control metadata

### DIFF
--- a/s3.py
+++ b/s3.py
@@ -17,6 +17,9 @@ def put(path, file, mimetype):
         Key=path,
         Body=file,
         ContentType=mimetype
+        Metadata={
+            'Cache-Control': 'max-age=604800'
+        }
     )
 
 def delete(path):


### PR DESCRIPTION
Set Cache-Control (one week) on the S3-object upon upload. Currently there is no cache-control on images from zfinger, which is sad :(

Will speed up the download of images from zfinger

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Bucket.put_object