### PR TITLE
fix: add cache field for resized images

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ MISSING_JPG = s3.get('missing.jpeg')['Body'].read()
 
 login_cache: Dict[str, Tuple[str, datetime]] = dict()
 
+# 3600 * 24 * 31 = 2678400 ie one month
 cache_timeout = 2678400
 
 def verify_token(token: str):

--- a/app.py
+++ b/app.py
@@ -28,8 +28,7 @@ MISSING_JPG = s3.get('missing.jpeg')['Body'].read()
 
 login_cache: Dict[str, Tuple[str, datetime]] = dict()
 
-# 3600 * 24 * 31 = 2678400 ie one month
-cache_timeout = 2678400
+cache_timeout = 3600 * 24 * 31 # one month
 
 def verify_token(token: str):
     match = re.search('^[A-Za-z0-9]+$', token)

--- a/s3.py
+++ b/s3.py
@@ -1,7 +1,7 @@
 import boto3
 from os import getenv
 
-BUCKET = getenv('S3_BUCKET', 'zfinger-test')
+BUCKET = getenv('S3_BUCKET', 'zfinger')
 
 client = boto3.client('s3')
 bucket = boto3.resource('s3').Bucket(BUCKET)

--- a/s3.py
+++ b/s3.py
@@ -1,7 +1,7 @@
 import boto3
 from os import getenv
 
-BUCKET = getenv('S3_BUCKET', 'zfinger')
+BUCKET = getenv('S3_BUCKET', 'zfinger-test')
 
 client = boto3.client('s3')
 bucket = boto3.resource('s3').Bucket(BUCKET)


### PR DESCRIPTION
Added a cache field to make sure that browsers also cache thumbnails. Also made sure to set the `Expires` HTTP field appropriately. This should make websites such as `val.datasektionen.se` more pleasant to use.

Ideally, we should use a caching CDN such as CloudFront to avoid having to resize the images on the fly, we can just cache them. In fact, I have implemented this internally for `Haj`, and it only took 5 minutes to setup. The relevant PR as reference: https://github.com/datasektionen/haj/pull/60